### PR TITLE
parse headers and variables 

### DIFF
--- a/src/api/getQuery.ts
+++ b/src/api/getQuery.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { QueryResponse } from '../types/types';
+import { ValidationError, parseString } from '../utils/validateRequest';
 
 // todo export interface from types!
 interface QueryRequest {
@@ -17,17 +18,24 @@ type QueryFn = ({
 }: QueryRequest) => Promise<string | QueryResponse>;
 
 export const getQuery: QueryFn = async ({ url, query, variables, headers }) => {
-  const body = { query, variables };
-
   try {
+    const parsedVariables = variables
+      ? parseString(variables, 'variables')
+      : {};
+    const parsedHeaders = headers ? parseString(headers, 'headers') : {};
+
+    const body = { query, variables: parsedVariables };
+
     const { data } = await axios.post<QueryResponse>(url, body, {
-      headers: { headers, 'Content-Type': 'application/json' },
+      headers: { ...parsedHeaders, 'Content-Type': 'application/json' },
+      validateStatus: (status) => status < 500,
     });
     return data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       return error.message;
     }
+    if (error instanceof ValidationError) return error.message;
     return 'An unexpected error occurred';
   }
 };

--- a/src/utils/validateRequest.ts
+++ b/src/utils/validateRequest.ts
@@ -1,0 +1,14 @@
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+export const parseString = (string: string, name: string) => {
+  try {
+    return JSON.parse(string);
+  } catch (error) {
+    throw new ValidationError(`Invalid syntax of ${name}`);
+  }
+};


### PR DESCRIPTION
- parse headers and variables from string to object befor sending request
- throw error, if headers and variables are not valid json

Добавила проверку в функцию апи перед запросом. Если есть идеи для более подходящего места для проверки формата - пишите. 
P.S. Мерж в heraders/variables, потому что от неё делала. 